### PR TITLE
Add regex rules functionality for account prediction

### DIFF
--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ananthakumaran/paisa/internal/model/portfolio"
 	"github.com/ananthakumaran/paisa/internal/model/posting"
 	"github.com/ananthakumaran/paisa/internal/model/price"
+	"github.com/ananthakumaran/paisa/internal/model/rule"
 	"github.com/ananthakumaran/paisa/internal/scraper"
 	"github.com/ananthakumaran/paisa/internal/scraper/india"
 	"github.com/ananthakumaran/paisa/internal/scraper/mutualfund"
@@ -31,6 +32,7 @@ func AutoMigrate(db *gorm.DB) {
 	db.AutoMigrate(&price.Price{})
 	db.AutoMigrate(&cii.CII{})
 	db.AutoMigrate(&cache.Cache{})
+	db.AutoMigrate(&rule.Rule{})
 }
 
 func SyncJournal(db *gorm.DB) (string, error) {

--- a/internal/model/rule/rule.go
+++ b/internal/model/rule/rule.go
@@ -1,0 +1,50 @@
+package rule
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// Rule represents a regex rule for account prediction
+type Rule struct {
+	ID        uint      `json:"id" gorm:"primaryKey"`
+	Pattern   string    `json:"pattern" gorm:"not null"`
+	Account   string    `json:"account" gorm:"not null"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// TableName overrides the table name
+func (Rule) TableName() string {
+	return "rules"
+}
+
+// Create creates a new rule
+func Create(db *gorm.DB, rule *Rule) error {
+	return db.Create(rule).Error
+}
+
+// FindAll returns all rules
+func FindAll(db *gorm.DB) ([]Rule, error) {
+	var rules []Rule
+	err := db.Find(&rules).Error
+	return rules, err
+}
+
+// FindByID returns a rule by ID
+func FindByID(db *gorm.DB, id uint) (Rule, error) {
+	var rule Rule
+	err := db.First(&rule, id).Error
+	return rule, err
+}
+
+// Update updates a rule
+func Update(db *gorm.DB, rule *Rule) error {
+	return db.Save(rule).Error
+}
+
+// Delete deletes a rule
+func Delete(db *gorm.DB, id uint) error {
+	return db.Delete(&Rule{}, id).Error
+}

--- a/internal/prediction/rules.go
+++ b/internal/prediction/rules.go
@@ -1,0 +1,110 @@
+package prediction
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/ananthakumaran/paisa/internal/model/rule"
+	"github.com/ananthakumaran/paisa/internal/query"
+	"gorm.io/gorm"
+)
+
+// TransactionDetails contains the details of a transaction for prediction
+type TransactionDetails struct {
+	Payee       string `json:"payee"`
+	Description string `json:"description"`
+	Account     string `json:"account"`
+}
+
+// PredictWithRules predicts the account for a transaction using rules
+func PredictWithRules(db *gorm.DB, details TransactionDetails) (string, bool) {
+	rules, err := rule.FindAll(db)
+	if err != nil {
+		return "", false
+	}
+
+	for _, r := range rules {
+		if matchesRule(r.Pattern, details) {
+			return r.Account, true
+		}
+	}
+
+	return "", false
+}
+
+// matchesRule checks if the transaction details match the rule pattern
+func matchesRule(pattern string, details TransactionDetails) bool {
+	// Handle complex expressions with AND, OR operators
+	if strings.Contains(pattern, " AND ") {
+		parts := strings.Split(pattern, " AND ")
+		for _, part := range parts {
+			part = strings.TrimSpace(part)
+			if !evaluateExpression(part, details) {
+				return false
+			}
+		}
+		return true
+	} else if strings.Contains(pattern, " OR ") {
+		parts := strings.Split(pattern, " OR ")
+		for _, part := range parts {
+			part = strings.TrimSpace(part)
+			if evaluateExpression(part, details) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Simple expression
+	return evaluateExpression(pattern, details)
+}
+
+// evaluateExpression evaluates a single expression against transaction details
+func evaluateExpression(expr string, details TransactionDetails) bool {
+	// Handle grouped expressions
+	if strings.HasPrefix(expr, "(") && strings.HasSuffix(expr, ")") {
+		return matchesRule(expr[1:len(expr)-1], details)
+	}
+
+	// Handle field-specific expressions
+	if strings.HasPrefix(expr, "payee=") {
+		value := strings.TrimPrefix(expr, "payee=")
+		return matchFieldValue(value, details.Payee)
+	} else if strings.HasPrefix(expr, "description=") {
+		value := strings.TrimPrefix(expr, "description=")
+		return matchFieldValue(value, details.Description)
+	} else if strings.HasPrefix(expr, "account=") {
+		value := strings.TrimPrefix(expr, "account=")
+		return matchFieldValue(value, details.Account)
+	}
+
+	// Default to matching against all fields
+	return matchFieldValue(expr, details.Payee) ||
+		matchFieldValue(expr, details.Description) ||
+		matchFieldValue(expr, details.Account)
+}
+
+// matchFieldValue checks if a field value matches a pattern
+func matchFieldValue(pattern, value string) bool {
+	// Handle regex patterns
+	if strings.HasPrefix(pattern, "~/") && strings.HasSuffix(pattern, "/i") {
+		// Case-insensitive regex
+		regexStr := pattern[2 : len(pattern)-2]
+		regex, err := regexp.Compile("(?i)" + regexStr)
+		if err != nil {
+			return false
+		}
+		return regex.MatchString(value)
+	} else if strings.HasPrefix(pattern, "~/") && strings.HasSuffix(pattern, "/") {
+		// Case-sensitive regex
+		regexStr := pattern[2 : len(pattern)-1]
+		regex, err := regexp.Compile(regexStr)
+		if err != nil {
+			return false
+		}
+		return regex.MatchString(value)
+	}
+
+	// Exact match
+	return pattern == value
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ananthakumaran/paisa/internal/config"
 	"github.com/ananthakumaran/paisa/internal/generator"
 	"github.com/ananthakumaran/paisa/internal/ledger"
+	"github.com/ananthakumaran/paisa/internal/model/rule"
 	"github.com/ananthakumaran/paisa/internal/model/template"
 	"github.com/ananthakumaran/paisa/internal/prediction"
 	"github.com/ananthakumaran/paisa/internal/server/assets"
@@ -322,6 +323,94 @@ func Build(db *gorm.DB, enableCompression bool) *gin.Engine {
 
 	router.GET("/api/account/tf_idf", func(c *gin.Context) {
 		c.JSON(200, prediction.GetTfIdf(db))
+	})
+
+	router.GET("/api/rules", func(c *gin.Context) {
+		rules, err := rule.FindAll(db)
+		if err != nil {
+			c.JSON(500, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(200, gin.H{"rules": rules})
+	})
+
+	router.POST("/api/rules", func(c *gin.Context) {
+		if config.GetConfig().Readonly {
+			c.JSON(403, gin.H{"error": "Readonly mode"})
+			return
+		}
+
+		var newRule rule.Rule
+		if err := c.ShouldBindJSON(&newRule); err != nil {
+			c.JSON(400, gin.H{"error": err.Error()})
+			return
+		}
+
+		if err := rule.Create(db, &newRule); err != nil {
+			c.JSON(500, gin.H{"error": err.Error()})
+			return
+		}
+
+		c.JSON(201, newRule)
+	})
+
+	router.PUT("/api/rules/:id", func(c *gin.Context) {
+		if config.GetConfig().Readonly {
+			c.JSON(403, gin.H{"error": "Readonly mode"})
+			return
+		}
+
+		id := c.Param("id")
+		var updatedRule rule.Rule
+		if err := c.ShouldBindJSON(&updatedRule); err != nil {
+			c.JSON(400, gin.H{"error": err.Error()})
+			return
+		}
+
+		var idUint uint
+		fmt.Sscanf(id, "%d", &idUint)
+		updatedRule.ID = idUint
+
+		if err := rule.Update(db, &updatedRule); err != nil {
+			c.JSON(500, gin.H{"error": err.Error()})
+			return
+		}
+
+		c.JSON(200, updatedRule)
+	})
+
+	router.DELETE("/api/rules/:id", func(c *gin.Context) {
+		if config.GetConfig().Readonly {
+			c.JSON(403, gin.H{"error": "Readonly mode"})
+			return
+		}
+
+		id := c.Param("id")
+		var idUint uint
+		fmt.Sscanf(id, "%d", &idUint)
+
+		if err := rule.Delete(db, idUint); err != nil {
+			c.JSON(500, gin.H{"error": err.Error()})
+			return
+		}
+
+		c.JSON(204, nil)
+	})
+
+	router.POST("/api/predict/rules", func(c *gin.Context) {
+		var details prediction.TransactionDetails
+		if err := c.ShouldBindJSON(&details); err != nil {
+			c.JSON(400, gin.H{"error": err.Error()})
+			return
+		}
+
+		account, found := prediction.PredictWithRules(db, details)
+		if !found {
+			c.JSON(404, gin.H{"error": "No matching rule found"})
+			return
+		}
+
+		c.JSON(200, gin.H{"account": account})
 	})
 
 	router.GET("/api/templates", func(c *gin.Context) {

--- a/src/lib/components/Navbar.svelte
+++ b/src/lib/components/Navbar.svelte
@@ -107,7 +107,14 @@
       label: "Ledger",
       href: "/ledger",
       children: [
-        { label: "Import", href: "/import", help: "import" },
+        { 
+          label: "Import", 
+          href: "/import", 
+          help: "import",
+          children: [
+            { label: "Rules", href: "/import/rules", help: "rules" }
+          ]
+        },
         { label: "Editor", href: "/editor", help: "editor", disablePreload: true },
         { label: "Transactions", href: "/transaction", help: "bulk-edit" },
         { label: "Postings", href: "/posting" },

--- a/src/routes/(app)/ledger/import/rules/+page.svelte
+++ b/src/routes/(app)/ledger/import/rules/+page.svelte
@@ -1,0 +1,397 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { goto } from "$app/navigation";
+  import { page } from "$app/stores";
+  import { toast } from "$lib/utils";
+  import { obscure } from "../../../../../persisted_store";
+
+  interface Rule {
+    id?: number;
+    pattern: string;
+    account: string;
+    created_at?: string;
+    updated_at?: string;
+  }
+
+  let rules: Rule[] = [];
+  let loading = true;
+  let newRule: Rule = { pattern: "", account: "" };
+  let editingRule: Rule | null = null;
+  let showAddForm = false;
+  let showEditForm = false;
+  let testPattern = "";
+  let testPayee = "";
+  let testDescription = "";
+  let testAccount = "";
+  let testResult = "";
+  let testLoading = false;
+
+  onMount(async () => {
+    await fetchRules();
+  });
+
+  async function fetchRules() {
+    loading = true;
+    try {
+      const response = await fetch("/api/rules");
+      const data = await response.json();
+      rules = data.rules || [];
+    } catch (error) {
+      console.error("Error fetching rules:", error);
+      toast("Error fetching rules", "danger");
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function addRule() {
+    try {
+      const response = await fetch("/api/rules", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify(newRule)
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || "Failed to add rule");
+      }
+
+      await fetchRules();
+      newRule = { pattern: "", account: "" };
+      showAddForm = false;
+      toast("Rule added successfully", "success");
+    } catch (error) {
+      console.error("Error adding rule:", error);
+      toast(error.message || "Error adding rule", "danger");
+    }
+  }
+
+  async function updateRule() {
+    if (!editingRule) return;
+
+    try {
+      const response = await fetch(`/api/rules/${editingRule.id}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify(editingRule)
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || "Failed to update rule");
+      }
+
+      await fetchRules();
+      editingRule = null;
+      showEditForm = false;
+      toast("Rule updated successfully", "success");
+    } catch (error) {
+      console.error("Error updating rule:", error);
+      toast(error.message || "Error updating rule", "danger");
+    }
+  }
+
+  async function deleteRule(id: number) {
+    if (!confirm("Are you sure you want to delete this rule?")) return;
+
+    try {
+      const response = await fetch(`/api/rules/${id}`, {
+        method: "DELETE"
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || "Failed to delete rule");
+      }
+
+      await fetchRules();
+      toast("Rule deleted successfully", "success");
+    } catch (error) {
+      console.error("Error deleting rule:", error);
+      toast(error.message || "Error deleting rule", "danger");
+    }
+  }
+
+  function startEdit(rule: Rule) {
+    editingRule = { ...rule };
+    showEditForm = true;
+  }
+
+  async function testRulePattern() {
+    testLoading = true;
+    testResult = "";
+
+    try {
+      const response = await fetch("/api/predict/rules", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          payee: testPayee,
+          description: testDescription,
+          account: testAccount
+        })
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        testResult = `Matched account: ${data.account}`;
+      } else if (response.status === 404) {
+        testResult = "No matching rule found";
+      } else {
+        const error = await response.json();
+        throw new Error(error.error || "Test failed");
+      }
+    } catch (error) {
+      console.error("Error testing rule:", error);
+      testResult = `Error: ${error.message || "Test failed"}`;
+    } finally {
+      testLoading = false;
+    }
+  }
+
+  function formatDate(dateString: string) {
+    if (!dateString) return "";
+    const date = new Date(dateString);
+    return date.toLocaleString();
+  }
+</script>
+
+<div class="container">
+  <div class="box">
+    <h1 class="title is-4">Account Prediction Rules</h1>
+    <p class="subtitle is-6 mb-4">
+      Create regex patterns to automatically assign accounts to transactions based on their details.
+    </p>
+
+    <div class="buttons mb-4">
+      <button class="button is-primary" on:click={() => (showAddForm = true)}>
+        <span class="icon">
+          <i class="fas fa-plus"></i>
+        </span>
+        <span>Add New Rule</span>
+      </button>
+    </div>
+
+    {#if showAddForm}
+      <div class="box">
+        <h2 class="title is-5">Add New Rule</h2>
+        <div class="field">
+          <label class="label">Pattern (Regex)</label>
+          <div class="control">
+            <input
+              class="input"
+              type="text"
+              placeholder="e.g. (account=Expenses:Unknown AND account=Liabilities:CreditCard:HDFC) AND (payee=~/google/i)"
+              bind:value={newRule.pattern}
+            />
+          </div>
+          <p class="help">
+            Use regex patterns to match transaction details. Use 'payee=', 'description=', and 'account=' to match specific fields.
+          </p>
+        </div>
+
+        <div class="field">
+          <label class="label">Target Account</label>
+          <div class="control">
+            <input
+              class="input"
+              type="text"
+              placeholder="e.g. Expenses:Business:Company"
+              bind:value={newRule.account}
+            />
+          </div>
+          <p class="help">The account to assign when this rule matches.</p>
+        </div>
+
+        <div class="field is-grouped mt-4">
+          <div class="control">
+            <button class="button is-primary" on:click={addRule}>Save Rule</button>
+          </div>
+          <div class="control">
+            <button class="button is-light" on:click={() => (showAddForm = false)}>Cancel</button>
+          </div>
+        </div>
+      </div>
+    {/if}
+
+    {#if showEditForm && editingRule}
+      <div class="box">
+        <h2 class="title is-5">Edit Rule</h2>
+        <div class="field">
+          <label class="label">Pattern (Regex)</label>
+          <div class="control">
+            <input
+              class="input"
+              type="text"
+              placeholder="e.g. (account=Expenses:Unknown AND account=Liabilities:CreditCard:HDFC) AND (payee=~/google/i)"
+              bind:value={editingRule.pattern}
+            />
+          </div>
+        </div>
+
+        <div class="field">
+          <label class="label">Target Account</label>
+          <div class="control">
+            <input
+              class="input"
+              type="text"
+              placeholder="e.g. Expenses:Business:Company"
+              bind:value={editingRule.account}
+            />
+          </div>
+        </div>
+
+        <div class="field is-grouped mt-4">
+          <div class="control">
+            <button class="button is-primary" on:click={updateRule}>Update Rule</button>
+          </div>
+          <div class="control">
+            <button class="button is-light" on:click={() => (showEditForm = false)}>Cancel</button>
+          </div>
+        </div>
+      </div>
+    {/if}
+
+    <div class="box mt-5">
+      <h2 class="title is-5">Test Rules</h2>
+      <p class="subtitle is-6 mb-4">
+        Test your rules against transaction details to see which account would be assigned.
+      </p>
+
+      <div class="columns">
+        <div class="column">
+          <div class="field">
+            <label class="label">Payee</label>
+            <div class="control">
+              <input
+                class="input"
+                type="text"
+                placeholder="e.g. Google Workspace"
+                bind:value={testPayee}
+              />
+            </div>
+          </div>
+        </div>
+        <div class="column">
+          <div class="field">
+            <label class="label">Description</label>
+            <div class="control">
+              <input
+                class="input"
+                type="text"
+                placeholder="e.g. Monthly subscription"
+                bind:value={testDescription}
+              />
+            </div>
+          </div>
+        </div>
+        <div class="column">
+          <div class="field">
+            <label class="label">Account</label>
+            <div class="control">
+              <input
+                class="input"
+                type="text"
+                placeholder="e.g. Liabilities:CreditCard:HDFC"
+                bind:value={testAccount}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="field">
+        <div class="control">
+          <button
+            class="button is-info"
+            on:click={testRulePattern}
+            disabled={testLoading}
+          >
+            <span class="icon">
+              <i class="fas fa-flask"></i>
+            </span>
+            <span>Test Rules</span>
+          </button>
+        </div>
+      </div>
+
+      {#if testResult}
+        <div class="notification {testResult.includes('Error') ? 'is-danger' : testResult.includes('No matching') ? 'is-warning' : 'is-success'}">
+          {testResult}
+        </div>
+      {/if}
+    </div>
+
+    <div class="mt-5">
+      <h2 class="title is-5">Existing Rules</h2>
+      {#if loading}
+        <div class="has-text-centered">
+          <span class="icon is-large">
+            <i class="fas fa-spinner fa-pulse"></i>
+          </span>
+          <p>Loading rules...</p>
+        </div>
+      {:else if rules.length === 0}
+        <div class="notification is-info">
+          No rules have been created yet. Add your first rule using the form above.
+        </div>
+      {:else}
+        <div class="table-container">
+          <table class="table is-fullwidth is-striped">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Pattern</th>
+                <th>Target Account</th>
+                <th>Created</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {#each rules as rule}
+                <tr>
+                  <td>{rule.id}</td>
+                  <td>
+                    <div class="is-family-monospace" style="max-width: 400px; overflow-wrap: break-word;">
+                      {$obscure ? "********" : rule.pattern}
+                    </div>
+                  </td>
+                  <td>{$obscure ? "********" : rule.account}</td>
+                  <td>{formatDate(rule.created_at)}</td>
+                  <td>
+                    <div class="buttons are-small">
+                      <button class="button is-info" on:click={() => startEdit(rule)}>
+                        <span class="icon">
+                          <i class="fas fa-edit"></i>
+                        </span>
+                      </button>
+                      <button class="button is-danger" on:click={() => deleteRule(rule.id)}>
+                        <span class="icon">
+                          <i class="fas fa-trash"></i>
+                        </span>
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        </div>
+      {/if}
+    </div>
+  </div>
+</div>
+
+<style>
+  .container {
+    max-width: 1200px;
+    margin: 0 auto;
+  }
+</style>


### PR DESCRIPTION
## Description
This PR adds a new feature to create and manage regex rules for automatic account prediction.

## Features Added
- Created a Rule model to store regex patterns and target accounts
- Added API endpoints for CRUD operations on rules
- Implemented a PredictWithRules function that matches transaction details against saved rules
- Added a UI page under Ledger > Import > Rules to manage rules
- Enhanced the Navbar to include the new Rules option

## How It Works
1. Users can create rules with complex regex patterns like `(account=Expenses:Unknown AND account=Liabilities:CreditCard:HDFC) AND (payee=~/google workspace/i OR payee=~/digitalocean/i)`
2. Each rule is associated with a target account (e.g., `Expenses:Business:Company`)
3. When importing transactions, the system can use these rules to automatically predict the correct account

## Testing
The UI includes a testing section where users can input transaction details and see which rule would match.